### PR TITLE
2020-04-22 GUARD-515 Order-Sync-Error

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "TeapplixAccess" ) ]
 [ assembly : AssemblyCompany( "Agile Harbor, LLC" ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2013 Agile Harbor, LLC" ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Teapplix webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.2.12.0" ) ]
+[ assembly : AssemblyVersion( "1.2.13.0" ) ]

--- a/src/TeapplixAccessTests/Report/TeapplixReportTests.cs
+++ b/src/TeapplixAccessTests/Report/TeapplixReportTests.cs
@@ -27,11 +27,10 @@ namespace TeapplixAccessTests.Report
 		public void Report_CreatedOrdersDownloaded()
 		{
 			var service = this.TeapplixFactory.CreateService( new TeapplixCredentials( this.Credentials.AccountName, this.Credentials.Login, this.Credentials.Password ) );
-			var report = service.GetCustomerReport( new TeapplixReportConfig( TeapplixReportSubaction.CustomerRunReport, new DateTime( 2010, 1, 22 ), new DateTime( 2014,5,9 ),
+			var report = service.GetCustomerReport( new TeapplixReportConfig( TeapplixReportSubaction.CustomerRunReport, new DateTime( 2020, 3, 22 ), new DateTime( 2020,4,22 ),
 				null, null ) );
 
-			var listResult = report.ToList();
-			listResult[ 0 ].TnxId.Should().Be( "51953672" );
+			report.Should().NotBeEmpty();
 		}
 
 		[ Test ]


### PR DESCRIPTION
Summary
Now order sync can skip order lines with wrong format.

Order sync uses API endpoint like this to retrieve orders:
https://app.teapplix.com/h/{{store}}/ea/admin.php?User={{user}}&Passwd={{passwd}}&Action=Report&Subaction=CustomerRun&start_date=2020/03/22&end_date=2020/04/22

The response is raw text similar to csv file. I've noticed that some lines with order information have broken structure, for example, the number of columns doesn't match header.
Example:

`generic,,10298930,,2020/03/23 09:56:00,Completed,,,,,Morenorabanales9@gmail.com,"9012390393","United States","TN","38115","Memphis","5392 cottonwood rd","",,407.30,0.00,0.00,0.00,0.00,2020/03/23,FEDEX,2Day/OR/PAK,9,391322047541,8.20,363878571,,,,,9,"(Premium Plus Quality) Black LCD Display Touch Digitizer Screen for iphone 6S",3,"i6-SS-Assembly (PP/ Black)",47.85,"(Premium Quality) Display LCD Touch Screen Digitizer For iPhone 8 Plus",2,"i8-Plus-Assembly (Premium / Black)",39.90,"(Premium Plus Quality) Black LCD Display Touch Digitizer Screen for iphone 8 Plus",2,"i8-Plus-Assembly ( PP / Black )",41.90,"Tempered Glass Screen Protector For Samsung Galaxy S10 Plus (Compatible w/ Fingerprint)",1,"SS-S10-Plus-TemperedGlass",2.95,"Prism Blue Display LCD Touch Screen Digitizer Frame For Samsung Galaxy S10 Plus",1,"SS-S10-Plus-Housing (Prism Blue)",209.95,"YF Rose Gold Home Button Solution Return Key for iPhone 7 | 7 Plus | 8 | 8 Plus (No Bluetooth Required)",1,"YF-Button (Rose)",8.95,"YF Silver Home Button Solution Return Key for iPhone 7 | 7 Plus | 8 | 8 Plus (No Bluetooth Required)",1,"YF-Button (Silver)",8.95,"10x Iphone 7 Plus | Iphone 8 Plus 9H Premium Tempered Glass LCD Screen Protector Guard",1,"i7-Plus-TemperedGlass",6.95,"(Premium Quality) White LCD`

`generic,,10298931,,2020/03/23 10:02:00,Completed,,,"Jonathan","Hang",jnang522@gmail.com,"7146009993",United States,"CA","92870","Placentia","1624 La Paloma Ave","",,134.90,0.00,0.00,0.00,0.00,2020/03/23,,,,Pick up,,,,,,,3,"Ship via My FedEx Account (within U.S). Account #:Pickup . FedEx Priority Overnight ® ",1,"",0.00,"Incell Display LCD Touch Screen Digitizer For iPhone XS Max (Shenchao Factory)",1,"iXS-MAX-Assembly (Shenchao)",114.95,"(Premium Quality) White LCD Touch Screen Digitizer For iPhone 7 Plus",1,"i7-Plus-Assembly (Premium / White)",19.95`

First line should also has extra information like subtotals. The second line is correct.